### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.h text working-tree-encoding=UTF-16 eol=crlf
+*.cpp text working-tree-encoding=UTF-16 eol=crlf
+# Auto detect text files and perform LF normalization
+* text=auto


### PR DESCRIPTION
此提交新建了gitattributes，可以使git在提交时将.cpp和.h文件自动转为UTF-8存储以使得git能将文件作为文本来处理、识别差异，而本地工作区仍然为UTF-16 BOM。
预计在本次提交之后，后续某文件被第二次修改时diff（文件差异）将恢复正常工作。
参考Git官方文档：https://git-scm.com/docs/gitattributes#_working_tree_encoding