### PR TITLE
添加无控制台模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@
 - **Right Ctrl + Left Key**       (-2)
 
 ## Command Line
- - unlocker.exe -[game] -[game argv...]
+ - unlocker.exe -[game] -[unlocker options before game options] -[game argv...]
  - eg. unlocker.exe -Genshin -screen-width 3840 -screen-height 1620 -screen-fullscreen 1
- - eg. unlocker.exe -HKSR -???
- - If you want start with mobile UI add the arg "**-EnableMobileUI**" **must be in the second**
- - unlocker.exe -[game] -EnableMobileUI -.......
- - DLL inject 
- - unlocker.exe -[game] -LoadLib [path]
+ - eg. unlocker.exe -HKSR -...
+ - Unlocker options include:
+   - `-EnableMobileUI`: Adds the parameter "**-EnableMobileUI**" to the launched game to conveniently enable mobile UI, e.g., `unlocker.exe -Genshin -EnableMobileUI`
+   - `-loadlib [absolute path]`: DLL injection, ensure the source is reliable before use, e.g., `unlocker.exe -[game] -loadlib [absolute path]`
+   - `-nc` or `--no-console`: No console mode (hides console window if config exists), e.g., `unlocker.exe -[game] -nc` or `unlocker.exe -[game] --no-console`
+ - Comprehensive example: `unlocker.exe -Genshin -EnableMobileUI -loadlib C:\\Folder\\plug.dll -nc -[game parameters...]`
 
 ## Inject
  - Now must be unlocked by inject 

--- a/README_zh_cn.md
+++ b/README_zh_cn.md
@@ -29,11 +29,11 @@
  - unlocker.exe -[游戏] -[给解锁器的参数在游戏参数前] -[游戏参数...]
  - 例 unlocker.exe -Genshin -screen-width 3840 -screen-height 1620 -screen-fullscreen 1
  - 例 unlocker.exe -HKSR -...
- - 在启动的游戏后面添加参数"**-EnableMobileUI**"来便捷启用移动端ui,该参数必须是**第二个**，否则无法被识别
- - unlocker.exe -Genshin -EnableMobileUI
- - DLL注入，使用前确保来源可靠性
- - unlocker.exe -[游戏] -loadlib [绝对路径]
- - unlocker.exe -Genshin -EnableMobileUI -loadlib C:\\Folder\\plug.dll -[游戏参数...]
+ - 给解锁器的参数包括
+   - `-EnableMobileUI`：在启动的游戏后面添加参数"**-EnableMobileUI**"来便捷启用移动端ui，例：`unlocker.exe -Genshin -EnableMobileUI`
+   - `-loadlib [绝对路径]`：DLL注入，使用前确保来源可靠性，例：`unlocker.exe -[游戏] -loadlib [绝对路径]`
+   - `-nc`或`--no-console`：无控制台模式（如果配置存在则隐藏控制台窗口），例：`unlocker.exe -[游戏] -nc`或`unlocker.exe -[游戏] --no-console`
+ - 综合示例：`unlocker.exe -Genshin -EnableMobileUI -loadlib C:\\Folder\\plug.dll -nc -[游戏参数...]`
 
 ### 默认热键           PS:按键要按一次改一次，不是长按
 - **END** 开/关


### PR DESCRIPTION
更新文档和代码以支持无控制台模式，重写了输入参数处理的逻辑

无控制台模式（-nc或--no-console参数，启动后不显示控制台）：
- 如不存在配置文件（第一次启动），则行为与不添加-nc参数相同
- 如存在配置文件（非第一次启动），则隐藏控制台窗口

重写的输入参数处理逻辑：
- 第一次循环遍历所有参数，处理解锁器相关参数
- 第二次循环遍历所有参数，跳过解锁器相关参数，拼接游戏相关参数