### PR TITLE
feat(core): add command-line FPS override and improve argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@
  - unlocker.exe -[game] -[game argv...]
  - eg. unlocker.exe -Genshin -screen-width 3840 -screen-height 1620 -screen-fullscreen 1
  - eg. unlocker.exe -HKSR -???
- - If you want start with mobile UI add the arg "**-EnableMobileUI**" **must be in the second**
+ - Unlocker args can appear anywhere after `-[game]` and will be consumed by the unlocker.
+ - All other args are passed through to the game process in the original order.
+ - Set FPS target: "**-fps**" [value] (decimals allowed; rounded to int)
+ - eg. unlocker.exe -Genshin -fps 120
+ - If you want start with mobile UI add the arg "**-EnableMobileUI**"
  - unlocker.exe -[game] -EnableMobileUI -.......
  - DLL inject 
  - unlocker.exe -[game] -LoadLib [path]

--- a/README_zh_cn.md
+++ b/README_zh_cn.md
@@ -26,10 +26,14 @@
 >使用管理员运行是因为游戏必须由解锁器启动，游戏本身就需要管理员权限了，所以负责启动的也是需要的
 
 ## 快速启动命令行
- - unlocker.exe -[游戏] -[给解锁器的参数在游戏参数前] -[游戏参数...]
- - 例 unlocker.exe -Genshin -screen-width 3840 -screen-height 1620 -screen-fullscreen 1
+ - unlocker.exe -[游戏] -[解锁器参数] -[游戏参数...]
+ - 例 unlocker.exe -Genshin -fps 120 -screen-width 3840 -screen-height 1620 -screen-fullscreen 1
  - 例 unlocker.exe -HKSR -...
- - 在启动的游戏后面添加参数"**-EnableMobileUI**"来便捷启用移动端ui,该参数必须是**第二个**，否则无法被识别
+ - 解锁器自己的参数（如 `-EnableMobileUI`、`-loadlib`）现在可以出现在 `-[游戏]` 后的任意位置，解锁器会自动识别并消费
+ - 除了解锁器参数以外的其他参数会按原顺序自动透传给游戏进程
+ - 启动参数设置目标帧率：添加参数 `-fps` [数值]（支持小数，会自动四舍五入到整数）
+ - 例 unlocker.exe -Genshin -fps 59.6
+ - 便捷启用移动端 UI：添加参数"**-EnableMobileUI**"
  - unlocker.exe -Genshin -EnableMobileUI
  - DLL注入，使用前确保来源可靠性
  - unlocker.exe -[游戏] -loadlib [绝对路径]


### PR DESCRIPTION
Reason:
- Users needed a way to set a target FPS directly via command line without modifying configuration files.
- When used with Apollo (a Sunshine fork), it can create a virtual display that matches the client’s FPS and read the FPS directly from environment variables, reducing manual configuration steps.
- The previous argument parser was position-dependent and fragile.

Changes:
- Added `-fps [value]` argument to override the target FPS.
- Refactored argument parsing to be order-independent for unlocker parameters (`-fps`, `-enablemobileui`, `-loadlib`).
- Implemented proper Windows-style argument quoting for game pass-through parameters to prevent command-line injection or parsing errors.
- Updated English and Chinese documentation to reflect new CLI usage.

Impact:
- Provides more flexibility for automated launching scripts.
- Improves reliability when passing complex arguments to the game.

Modified files:
- README.md
- README_zh_cn.md
- src/main.cpp